### PR TITLE
Avoid spin-locking in container init

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-service ssh start && while true; do sleep 1; done;
+service ssh start && tail -f /dev/null


### PR DESCRIPTION
Super minor optimization, but this relies on a signal that will never come instead of thrashing in and out of sleep. :) 